### PR TITLE
fix flask>=1.0 compatibility, fixes #116

### DIFF
--- a/borgweb/app.py
+++ b/borgweb/app.py
@@ -20,7 +20,7 @@ def create_app():
     app.register_blueprint(blueprint)
 
     app.jinja_env.globals['flaskg'] = flaskg
-    app.error_handler_spec[None][404] = err404
+    app.register_error_handler(404, err404)
 
     return app
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
     },
     setup_requires=['setuptools_scm>=1.7'],
     install_requires=[
-        'flask<1.0',
+        'flask>=0.7',  # >= 0.10 required for python 3
     ],
 )


### PR DESCRIPTION
register_error_handler method was added in flask 0.7,
thus require at least that.