### PR TITLE
[i18n] Add fr-FR & fr support

### DIFF
--- a/borgweb/static/i18n/fr-FR.json
+++ b/borgweb/static/i18n/fr-FR.json
@@ -1,0 +1,12 @@
+{
+	"Start Backup": "Lancer la sauvegarde",
+	"Start a backup": "Lancer une sauvegarde",
+	"Documentation": "Documentation",
+	"Open docs in new window": "Ouvrir la documentation dans une nouvelle fenêtre",
+	"See source code on Github": "Voir le code source sur Github",
+	"No logs found": "Aucun de fichier de logs trouvé",
+	"IRC Channel": "Canal IRC",
+	"Mailinglist": "List de diffusion",
+	"Beginning…": "Début…",
+	"End of file": "Fin de fichier"
+}

--- a/borgweb/static/i18n/fr.json
+++ b/borgweb/static/i18n/fr.json
@@ -1,0 +1,1 @@
+fr-FR.json


### PR DESCRIPTION
Some browsers use "fr" key, so use a symlink to fallback to fr-FR in
these situations.