### PR TITLE
Add instructions to install gulp for watch process

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,6 +34,8 @@ To install the complete environment for development you can do the following: ::
     ./borg-env/bin/borgweb
     
     # Start the watch process and Browsersync
+    # First install gulp
+    sudo npm install --global gulp-cli
     # In another shell navigate to `borgweb/js` and enter:
     gulp watch
 


### PR DESCRIPTION
I had an error "gulp: command does not exist" when running:
```bash
gulp watch
```

The proposed changes fixed this.